### PR TITLE
Filter out removable disks

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -423,6 +423,17 @@ func isValidDevice(name string) error {
 		}
 	}
 
+	// Check if removable disk (i.e. floppy disk)
+	removable := path.Join(sysfsPath, name, "removable")
+	if _, err := os.Stat(removable); err == nil {
+		removableValue, err := returnContentsAsInt(removable)
+		if err == nil {
+			if removableValue != 0 {
+				return fmt.Errorf("%s is a removable disk", name)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -127,8 +127,16 @@ render_config_file() {
     CONFIG_FILE_PATH=$DEFAULT_CONFIG_DIR/config.toml
     cat $BASE_DIR/config-template.toml | envsubst > $CONFIG_FILE_PATH
     for DISK_NAME in $DISK_DEVICE_NAMES; do
+        # filter out disk set as snapstore
         if [ "/dev/$DISK_NAME" = "$SNAPSTORE_DISK" ]; then
             continue
+        fi
+
+        # filter out removable disks (i.e. floppy disks)
+        if [ -f "/sys/block/$DISK_NAME/removable" ]; then
+            if [ "$(cat /sys/block/$DISK_NAME/removable)" != "0" ]; then
+                continue
+            fi
         fi
 
         echo "[[snapstore_mapping]]" >> $CONFIG_FILE_PATH


### PR DESCRIPTION
This patch sets a filter on removable disk devices, so they are ignored by the agent and the installer.