### PR TITLE
Improve installation script

### DIFF
--- a/scripts/install.go
+++ b/scripts/install.go
@@ -62,7 +62,7 @@ func RunInstall() {
 	scriptDir := filepath.Dir(scriptPath)
 	scriptCmd := fmt.Sprintf("%s %s %s", scriptPath, "-e", execPath)
 
-	cmd := exec.Command("sudo", "-E", "/bin/bash", "-c", scriptCmd)
+	cmd := exec.Command("/bin/bash", "-c", scriptCmd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -13,7 +13,7 @@ MODULES_PATH=/etc/modules
 PREREQS="gcc git make tar wget"
 
 STEP_VERSION="0.19.0"
-STEP_CLI_URL=https://dl.step.sm/gh-release/cli/docs-ca-install/v$STEP_VERSION/step_linux_${STEP_VERSION}_amd64.tar.gz
+STEP_CLI_URL=https://github.com/smallstep/cli/releases/download/v${STEP_VERSION}/step_linux_${STEP_VERSION}_amd64.tar.gz
 
 VEEAMSNAP_MODULE_PATH=/lib/modules/$(uname -r)/kernel/drivers/veeam/veeamsnap.ko
 VEEAMSNAP_REPO_URL=https://github.com/veeam/veeamsnap
@@ -40,7 +40,7 @@ EOF
 }
 
 install_step_cli() {
-    wget -O /tmp/step.tar.gz $STEP_CLI_URL
+    wget -O /tmp/step.tar.gz $STEP_CLI_URL || wget -O /tmp/step.tar.gz $STEP_CLI_URL --no-check-certificate
     tar -xf /tmp/step.tar.gz -C /tmp
     cp /tmp/step_$STEP_VERSION/bin/step /usr/bin
 }

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -10,7 +10,7 @@ DEFAULT_SNAPSTORE_LOCATION=/mnt/snapstores/snapstore_files
 CERTS_DIR=$DEFAULT_CONFIG_DIR/certs
 
 MODULES_PATH=/etc/modules
-PREREQS="gcc git make tar wget"
+PREREQS="e2fsprogs gcc git make tar wget"
 
 STEP_VERSION="0.19.0"
 STEP_CLI_URL=https://github.com/smallstep/cli/releases/download/v${STEP_VERSION}/step_linux_${STEP_VERSION}_amd64.tar.gz
@@ -45,9 +45,17 @@ install_step_cli() {
     cp /tmp/step_$STEP_VERSION/bin/step /usr/bin
 }
 
+install_prereqs_suse() {
+    KERNEL_TYPE=$(uname -r | cut -f 3 -d -)
+    KERNEL_VERSION=$(uname -r | cut -f 1,2 -d -)
+    VERSION=$(zypper search -si kernel-$KERNEL_TYPE | grep $KERNEL_VERSION | awk '{print $7}')
+    zypper install -y $PREREQS gcc11 gettext-tools iproute2 kernel-$KERNEL_TYPE-devel-$VERSION
+}
+
 install_prereqs() {
-    apt-get update || true
-    apt-get install -y $PREREQS gettext-base iproute2 linux-headers-$(uname -r) || yum install -y $PREREQS gettext iproute kernel-devel-$(uname -r)
+    apt-get update && apt-get install -y $PREREQS gettext-base iproute2 linux-headers-$(uname -r) || true
+    yum install -y $PREREQS gettext iproute kernel-devel-$(uname -r) || true
+    install_prereqs_suse || true
     install_step_cli
 }
 


### PR DESCRIPTION
This PR improves upon the following:

1) Fix SSL issues when installing the agent on older operating systems
    
    Some older operating systems' certificates can't be updated via their package
    managers, so the `step.sm` domain was seen as invalid when attempting to
    download the step client. This patch changes the download URL domain to
    the `github.com` one, tries to download without checking the
    certificates, in case it fails the first time.

2) Add support for SUSE-based operating systems
    
    This patch adds installation instructions for SUSE-based OSes, using the
    zypper package manager.

3) Improve installation persistence
    
    This patch fixes service not starting after reboot, by setting the
    required `veeamsnap` module to autoload, and also adding the snapstore
    disk to `/etc/fstab`, so it gets mounted on startup. This should make
    sure that the agent service is able to run after a system reboot.