### PR TITLE
Detect snapshot image device using udev monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine
 
 WORKDIR /root
 
-RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers
+RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers eudev-dev
 
 RUN git clone https://github.com/veeam/veeamsnap /tmp/veeamsnap
 RUN mkdir -p /usr/src/

--- a/cmd/coriolis-snapshot-agent/main.go
+++ b/cmd/coriolis-snapshot-agent/main.go
@@ -28,6 +28,7 @@ import (
 	"coriolis-snapshot-agent/apiserver/controllers"
 	"coriolis-snapshot-agent/apiserver/routers"
 	"coriolis-snapshot-agent/config"
+	"coriolis-snapshot-agent/internal/storage"
 	"coriolis-snapshot-agent/scripts"
 	"coriolis-snapshot-agent/util"
 	"coriolis-snapshot-agent/worker/manager"
@@ -70,7 +71,11 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	mgr, err := manager.NewManager(ctx, cfg)
+	udevMonitor := storage.NewUdevMonitor(ctx, cancel)
+	go udevMonitor.Start()
+	defer udevMonitor.Stop()
+
+	mgr, err := manager.NewManager(ctx, cfg, udevMonitor)
 	if err != nil {
 		log.Fatalf("failed to create manager: %q", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
+	github.com/farjump/go-libudev v0.0.0-20171109190736-8b0739cd6d0b // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47
 	github.com/shirou/gopsutil/v3 v3.21.5

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 h1:5sXbqlSomvdjl
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/farjump/go-libudev v0.0.0-20171109190736-8b0739cd6d0b h1:zMD1x/LqZnujKnuquz9rbl/P6HZomUj0YXD/yxEAXXM=
+github.com/farjump/go-libudev v0.0.0-20171109190736-8b0739cd6d0b/go.mod h1:yzTdDrJ3rMj/15/ayeyb6HhTtu7VClWfiarB328Iew0=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
@@ -15,6 +17,8 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1 h1:smvLGU3obGU5kny71BtE/ibR0wIXRUiRFDmSn0Nxz1E=
+github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1/go.mod h1:fP/NdyhRVOv09PLRbVXrSqHhrfQypdZwgE2L4h2U5C8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/storage/udev_monitor.go
+++ b/internal/storage/udev_monitor.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	udev "github.com/farjump/go-libudev"
+	"github.com/pkg/errors"
+)
+
+type DeviceStatus string
+
+const (
+	DeviceStatusActive   DeviceStatus = "active"
+	DeviceStatusInactive DeviceStatus = "inactive"
+	DeviceStatusUnknown  DeviceStatus = "unknown"
+	udevActionAdd                     = "add"
+	udevActionRemove                  = "remove"
+)
+
+type UdevDevice struct {
+	DeviceNode   string
+	DeviceStatus DeviceStatus
+}
+
+type UdevMonitor struct {
+	cancel  context.CancelFunc
+	ctx     context.Context
+	monitor *udev.Monitor
+	devices sync.Map
+}
+
+func NewUdevMonitor(ctx context.Context, cancel context.CancelFunc) (monitor *UdevMonitor) {
+	u := udev.Udev{}
+	m := u.NewMonitorFromNetlink("udev")
+	m.FilterAddMatchSubsystemDevtype("block", "disk")
+	ret := &UdevMonitor{
+		cancel:  cancel,
+		ctx:     ctx,
+		monitor: m,
+		devices: sync.Map{},
+	}
+
+	return ret
+}
+
+func (m *UdevMonitor) Start() {
+	ch, _ := m.monitor.DeviceChan(m.ctx)
+	for d := range ch {
+		device := UdevDevice{
+			DeviceNode:   d.Devnode(),
+		}
+		devKey := fmt.Sprintf("%d-%d", d.Devnum().Major(), d.Devnum().Minor())
+		switch d.Action() {
+		case udevActionAdd:
+			device.DeviceStatus = DeviceStatusActive
+		case udevActionRemove:
+			m.devices.Delete(devKey)
+		default:
+			device.DeviceStatus = DeviceStatusUnknown
+		}
+
+		log.Printf("Udev device event detected, adding to monitor devices: %s -> %+v", devKey, device)
+		m.devices.Store(devKey, device)
+	}
+}
+
+func (m *UdevMonitor) Stop() {
+	m.cancel()
+}
+
+func (m *UdevMonitor) GetUdevDevice(major int, minor int) (UdevDevice, error) {
+	devKey := fmt.Sprintf("%d-%d", major, minor)
+	attempts := 0
+	for {
+		if attempts >= 60 {
+			return UdevDevice{}, errors.Errorf("Failed to detect device %d:%d", major, minor)
+		}
+		if foundDev, ok := m.devices.Load(devKey); ok {
+			device := foundDev.(UdevDevice)
+			log.Printf("Detected udev device with ID %d:%d -> %+v", major, minor, device)
+			return device, nil
+		}
+		attempts++
+		time.Sleep(1 * time.Second)
+	}
+}


### PR DESCRIPTION
Adds udev monitor that detects the snapshot image device information when creating a new snapshot, instead of reading the information from `/sys/block`, since removable block device filtering is enabled, and snapshot images are removable virtual disks.