### PR TITLE
Fix snapstore disk identification

### DIFF
--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -119,7 +119,7 @@ render_config_file() {
     cat $BASE_DIR/config-template.toml | envsubst > $CONFIG_FILE_PATH
     for DISK_NAME in $DISK_DEVICE_NAMES; do
         # filter out disk set as snapstore
-        if [ "/dev/$DISK_NAME" = "$SNAPSTORE_DISK" ]; then
+        if [ "$DISK_NAME" = "$SNAPSTORE_DISK" ]; then
             continue
         fi
 


### PR DESCRIPTION
Fixes a bug where, when running the installation script, the snapstore disk name is not skipped when rendering the snapstore mappings.