### PR TITLE
Fix ioctl `function not implemented` error when adding disk to tracking

### DIFF
--- a/cmd/coriolis-snapshot-agent/main.go
+++ b/cmd/coriolis-snapshot-agent/main.go
@@ -28,6 +28,7 @@ import (
 	"coriolis-snapshot-agent/apiserver/controllers"
 	"coriolis-snapshot-agent/apiserver/routers"
 	"coriolis-snapshot-agent/config"
+	"coriolis-snapshot-agent/internal/ioctl"
 	"coriolis-snapshot-agent/internal/storage"
 	"coriolis-snapshot-agent/scripts"
 	"coriolis-snapshot-agent/util"
@@ -70,6 +71,10 @@ func main() {
 	log.SetOutput(logWriter)
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := ioctl.SetMissingKernelEntries(); err != nil {
+		log.Fatalf("Error setting missing kernel entries: %+v\n", err)
+	}
 
 	udevMonitor := storage.NewUdevMonitor(ctx, cancel)
 	go udevMonitor.Start()

--- a/internal/ioctl/veeam_ioctl.go
+++ b/internal/ioctl/veeam_ioctl.go
@@ -20,6 +20,8 @@ const (
 	VEEAM_DEV  = "/dev/veeamsnap"
 
 	SNAP_STORE_NOT_FOUND = 0xffffffffffffffff
+
+	KERNEL_ENTRY_BASE_NAME = "__request_module"
 )
 
 var (
@@ -53,4 +55,8 @@ var (
 
 	// persistent CBT data parameter
 	IOCTL_PERSISTENTCBT_DATA uintptr = 2148292168
+
+	// kernel entry resolvers
+	IOCTL_GET_UNRESOLVED_KERNEL_ENTRIES uintptr = 2415941129
+	IOCTL_SET_KERNEL_ENTRIES            uintptr = 1074550280
 )

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -90,6 +90,9 @@ copy_agent_binary() {
     if [ "$1" != "$DEFAUL_BINARY_PATH" ]; then
         cp $1 $DEFAULT_BINARY_PATH
     fi
+
+    # setting caps required to set kernel entry addresses from /proc/kallsyms
+    setcap 'CAP_SYSLOG+ep' $DEFAULT_BINARY_PATH
 }
 
 render_config_file() {


### PR DESCRIPTION
This patch fixes the unimplemented ioctl call by adding the missing kernel entries,
using the veeamsnap ioctl calls `get_unresolved_kernel_entries` to get the missing
entries, and `set_kernel_entries` to set them. After setting these kernel entries to
the module, the `tracking_add` call returns successfully.

This patch also adds a new flag `-ksym-address` which, given the kernel entry name,
returns the found address from the /proc/kallsyms file. Since this file can only be
properly read by root, the executable should always be run as root with this flag
(i.e. by using sudo). This is exactly what its done in this patch when attempting
to resolve kernel entries, in the attempt of keeping the agent running as a non-root
user.