### PR TITLE
Filter out swap disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Within the kernel module, tracking is the process by which an individual block v
 
 Coriolis treats all machines it migrates as black boxes. So this agent will always track raw block volumes, regardless of what they contain. We do not care about device mappers or filesystems residing on those volumes.
 
+WARNING! The agent does not support tracking or transferring swap or virtual disks. The aim of this agent is covering migration of physical servers to virtual space. There is no point in tracking changes of such disks, therefore the agent filters them out. The lack of swap disks should not interfere with the server booting on a destination platform, but its performance should still be checked, and, if needed, eventually raise the destination machine's memory.
+
 ### Snap store
 
 As mentioned, the kernel module enables block level copy-on-write snapshots of physical disks on a running linux system. But any copy-on-write system needs a place to copy any changed blocks that need to remain private to a particular snapshot. That is where snap stores come in. A snap store is a container in which the CoW data can be stored. The kernel module gives us 3 options here:

--- a/apiserver/controllers/controllers.go
+++ b/apiserver/controllers/controllers.go
@@ -48,7 +48,9 @@ type APIController struct {
 func (a *APIController) ListDisksHandler(w http.ResponseWriter, r *http.Request) {
 	includeVirtualArg := r.URL.Query().Get("includeVirtual")
 	includeVirtual := parseBoolParam(includeVirtualArg, false)
-	disks, err := a.mgr.ListDisks(includeVirtual)
+	includeSwapArg := r.URL.Query().Get("includeSwap")
+	includeSwap := parseBoolParam(includeSwapArg, false)
+	disks, err := a.mgr.ListDisks(includeVirtual, includeSwap)
 	if err != nil {
 		log.Printf("failed to list disks: %q", err)
 		handleError(w, err)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
-	github.com/farjump/go-libudev v0.0.0-20171109190736-8b0739cd6d0b // indirect
+	github.com/farjump/go-libudev v0.0.0-20171109190736-8b0739cd6d0b
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -454,7 +454,7 @@ func GetBlockDeviceInfo(name string) (BlockVolume, error) {
 // BlockDeviceList returns a list of BlockVolume structures, populated with
 // information about locally visible disks. This does not include the block
 // device chunks.
-func BlockDeviceList(ignoreMounted bool, includeVirtual bool) ([]BlockVolume, error) {
+func BlockDeviceList(ignoreMounted bool, includeVirtual bool, includeSwap bool) ([]BlockVolume, error) {
 	devList, err := ioutil.ReadDir(sysfsPath)
 	if err != nil {
 		return nil, err
@@ -483,6 +483,9 @@ func BlockDeviceList(ignoreMounted bool, includeVirtual bool) ([]BlockVolume, er
 		if ignoreMounted && hasMounted {
 			continue
 		}
+		if info.FilesystemType == "swap" && !includeSwap {
+			continue
+		}
 		ret = append(ret, info)
 	}
 	return ret, nil
@@ -491,7 +494,7 @@ func BlockDeviceList(ignoreMounted bool, includeVirtual bool) ([]BlockVolume, er
 // FindDeviceByID returns the path in /dev to a device identified
 // by major:minor.
 func FindDeviceByID(major uint32, minor uint32) (string, error) {
-	devices, err := BlockDeviceList(false, true)
+	devices, err := BlockDeviceList(false, true, true)
 	if err != nil {
 		return "", errors.Wrap(err, "fetching devices")
 	}
@@ -514,7 +517,7 @@ func FindDeviceByID(major uint32, minor uint32) (string, error) {
 // FindBlockVolumeByID returns a BlockVolume{} that identifies the device with
 // major:minor.
 func FindBlockVolumeByID(major uint32, minor uint32) (BlockVolume, error) {
-	devices, err := BlockDeviceList(false, true)
+	devices, err := BlockDeviceList(false, true, true)
 	if err != nil {
 		return BlockVolume{}, errors.Wrap(err, "fetching devices")
 	}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -246,7 +246,7 @@ func GetSystemInfo(mgr *manager.Snapshot) (SystemInfo, error) {
 		return SystemInfo{}, errors.Wrap(err, "fetching CPU info")
 	}
 
-	disks, err := mgr.ListDisks(false)
+	disks, err := mgr.ListDisks(false, false)
 	if err != nil {
 		return SystemInfo{}, errors.Wrap(err, "fetching disk info")
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -61,7 +61,7 @@ type FileSystemInfo struct {
 // of individual partitions.
 func FindAllInvolvedDevices(devices []types.DevID) ([]string, error) {
 	var ret []string
-	allDevices, err := storage.BlockDeviceList(false, true)
+	allDevices, err := storage.BlockDeviceList(false, true, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching devices")
 	}
@@ -111,7 +111,7 @@ func GetBlockDeviceInfoFromFile(path string) (PhysicalDiskInfo, error) {
 	major := unix.Major(sysStat.Dev)
 	minor := unix.Minor(sysStat.Dev)
 
-	devices, err := storage.BlockDeviceList(false, true)
+	devices, err := storage.BlockDeviceList(false, true, true)
 	if err != nil {
 		return PhysicalDiskInfo{}, errors.Wrap(err, "fetching block devices")
 	}
@@ -215,7 +215,7 @@ func GetFileRanges(filePath string) ([]types.Range, types.DevID, error) {
 }
 
 func FindDeviceByPath(path string) (types.DevID, error) {
-	devices, err := storage.BlockDeviceList(false, true)
+	devices, err := storage.BlockDeviceList(false, true, true)
 	if err != nil {
 		return types.DevID{}, errors.Wrap(err, "fetching block devices")
 	}

--- a/worker/manager/initialization.go
+++ b/worker/manager/initialization.go
@@ -99,7 +99,7 @@ func (m *Snapshot) initTrackedDisks() (err error) {
 		return nil
 	}
 	// listDisks excludes disks configured as snap store destinations.
-	disks, err := m.listDisks(false)
+	disks, err := m.listDisks(false, false)
 	if err != nil {
 		return errors.Wrap(err, "fetching disks list")
 	}

--- a/worker/manager/manager.go
+++ b/worker/manager/manager.go
@@ -188,8 +188,8 @@ func (m *Snapshot) Unlock() {
 	m.mux.Unlock()
 }
 
-func (m *Snapshot) listDisks(includeVirtual bool) ([]storage.BlockVolume, error) {
-	devices, err := storage.BlockDeviceList(false, includeVirtual)
+func (m *Snapshot) listDisks(includeVirtual bool, includeSwap bool) ([]storage.BlockVolume, error) {
+	devices, err := storage.BlockDeviceList(false, includeVirtual, includeSwap)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing devices")
 	}
@@ -222,8 +222,8 @@ func (m *Snapshot) listDisks(includeVirtual bool) ([]storage.BlockVolume, error)
 	return ret, nil
 }
 
-func (m *Snapshot) ListDisks(includeVirtual bool) ([]params.BlockVolume, error) {
-	devices, err := m.listDisks(includeVirtual)
+func (m *Snapshot) ListDisks(includeVirtual bool, includeSwap bool) ([]params.BlockVolume, error) {
+	devices, err := m.listDisks(includeVirtual, includeSwap)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing devices")
 	}
@@ -270,7 +270,7 @@ func (m *Snapshot) GetTrackedDisk(diskID string) (params.BlockVolume, error) {
 }
 
 func (m *Snapshot) findDiskByPath(path string) (storage.BlockVolume, error) {
-	disks, err := m.listDisks(true)
+	disks, err := m.listDisks(true, true)
 	if err != nil {
 		return storage.BlockVolume{}, errors.Wrap(err, "fetching disk list")
 	}


### PR DESCRIPTION
This patch will filter out disk devices of type "swap", as we don't need to keep track and transfer swap disk information.