### PR TITLE
Fix binary build

### DIFF
--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -3,4 +3,4 @@
 SNAPSHOTTER_SOURCE="/build/coriolis-snapshot-agent"
 
 cd $SNAPSHOTTER_SOURCE/cmd/coriolis-snapshot-agent
-go build -o $SNAPSHOTTER_SOURCE/coriolis-snapshot-agent -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --always --dirty)" .
+go build -buildvcs=false -o $SNAPSHOTTER_SOURCE/coriolis-snapshot-agent -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --always --dirty)" .


### PR DESCRIPTION
FIxes Go build that errors because it cannot read VCS stamping. It does that by disabling VCS building.