### PR TITLE
Set git tag as binary version

### DIFF
--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -3,4 +3,5 @@
 SNAPSHOTTER_SOURCE="/build/coriolis-snapshot-agent"
 
 cd $SNAPSHOTTER_SOURCE/cmd/coriolis-snapshot-agent
-go build -buildvcs=false -o $SNAPSHOTTER_SOURCE/coriolis-snapshot-agent -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --always --dirty)" .
+git config --global --add safe.directory $SNAPSHOTTER_SOURCE
+go build -buildvcs=false -o $SNAPSHOTTER_SOURCE/coriolis-snapshot-agent -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags)" .


### PR DESCRIPTION
This change will make sure that the git tag version is passed over to the binary, therefore it can be printed out using the `-version` flag. This tag version gets passed on every binary build, so no need to ever change it in the code.